### PR TITLE
fix(frontend): source-control multi-connector + AI dialog envelope + digest dup-keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -290,7 +290,7 @@ GOOGLE_CLIENT_SECRET=your-google-client-secret
 # (claw-connector-service) and installed Ollama models (claw-ollama-service).
 # DO NOT pin a specific local model here; the system resolves the best
 # available model per action kind based on what's actually present.
-AI_ACTION_REQUEST_TIMEOUT_MS=120000
+AI_ACTION_REQUEST_TIMEOUT_MS=300000
 AI_ACTION_MODEL_RESOLVER_TTL_SECONDS=300
 
 # Workspace AI Action Approval Engine (Stream 10)

--- a/apps/claw-chat-service/src/modules/chat-messages/managers/chat-execution.manager.ts
+++ b/apps/claw-chat-service/src/modules/chat-messages/managers/chat-execution.manager.ts
@@ -601,20 +601,38 @@ export class ChatExecutionManager implements OnModuleInit {
   ): Promise<InternalGenerateResponse> {
     const config = AppConfig.get();
     const { baseUrl, apiKey } = await this.resolveProviderConfig(provider);
-    const body: OpenAiChatRequest = {
-      model,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userPrompt },
-      ],
-      stream: false,
-    };
-    if (maxTokens !== undefined) {
-      body.max_tokens = Math.min(maxTokens, HARD_MAX_OUTPUT_TOKENS);
-    }
+    const isOllamaConnector = provider === OLLAMA_CONNECTOR_PROVIDER;
+    // Cloud Ollama (and any other provider routed through the OLLAMA
+    // connector) speaks the *native* Ollama chat API at `/api/chat`, not
+    // the OpenAI-compat path. resolveOllamaConnectorBaseUrl already pins
+    // baseUrl to end with `/api`, so the URL here is `${baseUrl}/chat`.
+    // Body is the native Ollama shape (`options.num_predict` instead of
+    // OpenAI's top-level `max_tokens`); response shape is also native.
+    const url = isOllamaConnector ? `${baseUrl}/chat` : `${baseUrl}/chat/completions`;
+    const messages = [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ];
+    const body: OpenAiChatRequest | OllamaChatRequest = isOllamaConnector
+      ? {
+          model,
+          messages,
+          stream: false,
+          ...(maxTokens === undefined
+            ? {}
+            : { options: { num_predict: Math.min(maxTokens, HARD_MAX_OUTPUT_TOKENS) } }),
+        }
+      : {
+          model,
+          messages,
+          stream: false,
+          ...(maxTokens === undefined
+            ? {}
+            : { max_tokens: Math.min(maxTokens, HARD_MAX_OUTPUT_TOKENS) }),
+        };
     const startTime = Date.now();
-    const response = await httpRequest<OpenAiChatResponse>({
-      url: `${baseUrl}/chat/completions`,
+    const response = await httpRequest<OpenAiChatResponse | OllamaChatResponse>({
+      url,
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}` },
       body,
@@ -629,13 +647,21 @@ export class ChatExecutionManager implements OnModuleInit {
         'CLOUD_PROVIDER_REQUEST_FAILED',
       );
     }
-    const parsed = this.parseCloudResponse(
-      response.data as OpenAiChatResponse,
-      provider,
-      model,
-      startTime,
-      false,
-    );
+    const parsed = isOllamaConnector
+      ? this.parseOllamaChatResponse(
+          response.data as OllamaChatResponse,
+          provider,
+          model,
+          startTime,
+          false,
+        )
+      : this.parseCloudResponse(
+          response.data as OpenAiChatResponse,
+          provider,
+          model,
+          startTime,
+          false,
+        );
     return {
       content: parsed.content,
       provider: parsed.provider,

--- a/apps/claw-frontend/src/components/ai/ai-action-dialog.tsx
+++ b/apps/claw-frontend/src/components/ai/ai-action-dialog.tsx
@@ -93,7 +93,7 @@ export function AiActionDialog({
               <div className="flex items-center justify-between text-xs text-muted-foreground">
                 <span>
                   {t('aiActions.dialog.generated_by', {
-                    model: ctrl.result.generatedBy.displayName,
+                    model: ctrl.result.generatedBy?.displayName ?? '—',
                   })}
                 </span>
                 <Button

--- a/apps/claw-frontend/src/components/digest/digest-section-card.tsx
+++ b/apps/claw-frontend/src/components/digest/digest-section-card.tsx
@@ -3,8 +3,12 @@
 import type { ReactElement } from 'react';
 
 import type { DigestSectionCardProps } from '@/types/workspace-digest.types';
+import { withDedupedKeys } from '@/utilities/stable-keys.utility';
 
 export function DigestSectionCard({ section, t }: DigestSectionCardProps): ReactElement {
+  const highlightItems = withDedupedKeys(section.highlights, (h) => h);
+  const actionItemEntries = withDedupedKeys(section.actionItems, (a) => a.title);
+
   return (
     <div className="flex flex-col gap-2 rounded-lg border border-border bg-card p-4">
       <div className="flex items-center gap-2">
@@ -19,8 +23,8 @@ export function DigestSectionCard({ section, t }: DigestSectionCardProps): React
             {t('digest.section.highlights')}
           </span>
           <ul className="ml-4 list-disc space-y-1 text-xs text-muted-foreground">
-            {section.highlights.map((h, i) => (
-              <li key={`${i}-${h}`}>{h}</li>
+            {highlightItems.map(({ key, item }) => (
+              <li key={key}>{item}</li>
             ))}
           </ul>
         </div>
@@ -31,11 +35,11 @@ export function DigestSectionCard({ section, t }: DigestSectionCardProps): React
             {t('digest.section.actionItems')}
           </span>
           <ul className="ml-4 list-disc space-y-1 text-xs">
-            {section.actionItems.map((a) => (
-              <li key={a.title}>
-                <span className="font-medium">{a.title}</span>
-                {a.description.length > 0 ? (
-                  <span className="text-muted-foreground"> — {a.description}</span>
+            {actionItemEntries.map(({ key, item }) => (
+              <li key={key}>
+                <span className="font-medium">{item.title}</span>
+                {item.description.length > 0 ? (
+                  <span className="text-muted-foreground"> — {item.description}</span>
                 ) : null}
               </li>
             ))}

--- a/apps/claw-frontend/src/components/digest/digest-section-card.tsx
+++ b/apps/claw-frontend/src/components/digest/digest-section-card.tsx
@@ -19,8 +19,8 @@ export function DigestSectionCard({ section, t }: DigestSectionCardProps): React
             {t('digest.section.highlights')}
           </span>
           <ul className="ml-4 list-disc space-y-1 text-xs text-muted-foreground">
-            {section.highlights.map((h) => (
-              <li key={h}>{h}</li>
+            {section.highlights.map((h, i) => (
+              <li key={`${i}-${h}`}>{h}</li>
             ))}
           </ul>
         </div>

--- a/apps/claw-frontend/src/hooks/workspace/use-source-control-page.ts
+++ b/apps/claw-frontend/src/hooks/workspace/use-source-control-page.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { SOURCE_CONTROL_PROVIDERS } from '../../constants/source-control.constants';
 import type { AiActionKind } from '../../enums/ai-action-kind.enum';
@@ -6,6 +6,7 @@ import type { WorkspaceActionType } from '../../enums/workspace-action-type.enum
 import { WorkspaceObjectType } from '../../enums/workspace-object-type.enum';
 import type { UseSourceControlPageResult } from '../../types/source-control.types';
 import type { WorkspaceObject } from '../../types/workspace.types';
+import { dedupeWorkspaceObjectsByProviderAndExternalId } from '../../utilities/source-control.utility';
 
 import { useCreateWorkspaceAction } from './use-workspace-action-mutations';
 import { useWorkspaceConnectors } from './use-workspace-connectors';
@@ -13,6 +14,11 @@ import { useWorkspaceObjects } from './use-workspace-objects';
 
 export function useSourceControlPage(): UseSourceControlPageResult {
   const { data: connectorsData } = useWorkspaceConnectors();
+  // We don't pin to a single connector here — the user may have several
+  // GitHub/GitLab/Bitbucket connectors (e.g. multiple orgs or test accounts)
+  // and PRs land under whichever one synced them. The page just needs to
+  // know that at least one source-control connector exists; the PR list is
+  // queried unscoped and naturally aggregates across all of them.
   const connector = connectorsData?.data?.find((c) =>
     SOURCE_CONTROL_PROVIDERS.includes(c.provider),
   );
@@ -22,9 +28,16 @@ export function useSourceControlPage(): UseSourceControlPageResult {
     isLoading,
     isError,
   } = useWorkspaceObjects(
-    connector !== undefined
-      ? { connectorId: connector.id, type: WorkspaceObjectType.PULL_REQUEST }
-      : undefined,
+    connector !== undefined ? { type: WorkspaceObjectType.PULL_REQUEST } : undefined,
+  );
+
+  // Each connector that synced the same repo gets its own copy of every PR
+  // row keyed by (connectorId, externalId). Across connectors that means the
+  // same upstream PR can show up N times in the unfiltered list — dedupe by
+  // (provider, externalId), keeping whichever copy synced most recently.
+  const pullRequests = useMemo(
+    () => dedupeWorkspaceObjectsByProviderAndExternalId(prsData?.data ?? []),
+    [prsData?.data],
   );
 
   const [selectedPr, setSelectedPr] = useState<WorkspaceObject | null>(null);
@@ -59,7 +72,7 @@ export function useSourceControlPage(): UseSourceControlPageResult {
 
   return {
     connector,
-    pullRequests: prsData?.data ?? [],
+    pullRequests,
     isLoading,
     isError,
     selectedPr,

--- a/apps/claw-frontend/src/repositories/ai-actions/ai-actions.repository.ts
+++ b/apps/claw-frontend/src/repositories/ai-actions/ai-actions.repository.ts
@@ -23,7 +23,24 @@ export type RunAiActionBody = {
   preferredModel?: ModelChoice;
 };
 
+// Backend returns RunAiActionEnvelope: `{mode:'EXECUTED', execution}` or `{mode:'QUEUED', queue}`.
+// The dialog flow always wants the actual generated content, so we hit `?execute=immediate`
+// and unwrap the EXECUTED branch. If for any reason the backend returns the QUEUED branch
+// (e.g. policy gate forced enqueue server-side), we throw so the mutation surfaces an error
+// rather than handing the dialog a result without a `generatedBy` field.
+type RunAiActionEnvelope =
+  | { mode: 'EXECUTED'; execution: AiActionResult }
+  | { mode: 'QUEUED'; queue: { queueId: string; status: string } };
+
 export async function runAiAction(request: RunAiActionBody): Promise<AiActionResult> {
-  const response = await apiClient.post<AiActionResult>(`${BASE}/run`, request);
-  return response.data;
+  const response = await apiClient.post<RunAiActionEnvelope>(
+    `${BASE}/run?execute=immediate`,
+    request,
+  );
+  if (response.data.mode === 'EXECUTED') {
+    return response.data.execution;
+  }
+  throw new Error(
+    `AI action was queued for approval (queueId=${response.data.queue.queueId}); the dialog cannot display queued results.`,
+  );
 }

--- a/apps/claw-frontend/src/repositories/ai-actions/ai-actions.repository.ts
+++ b/apps/claw-frontend/src/repositories/ai-actions/ai-actions.repository.ts
@@ -33,9 +33,15 @@ type RunAiActionEnvelope =
   | { mode: 'QUEUED'; queue: { queueId: string; status: string } };
 
 export async function runAiAction(request: RunAiActionBody): Promise<AiActionResult> {
+  // LLM generation can take well over the 30s default axios timeout (slow
+  // local Ollama models routinely sit at 60-120s). Pass `timeout: 0` to
+  // disable the client-side cutoff — the backend's
+  // AI_ACTION_REQUEST_TIMEOUT_MS (default 300s) and nginx proxy_read_timeout
+  // bound the upper end. Frontend just waits for whichever fires first.
   const response = await apiClient.post<RunAiActionEnvelope>(
     `${BASE}/run?execute=immediate`,
     request,
+    { timeout: 0 },
   );
   if (response.data.mode === 'EXECUTED') {
     return response.data.execution;

--- a/apps/claw-frontend/src/services/shared/api-client.ts
+++ b/apps/claw-frontend/src/services/shared/api-client.ts
@@ -13,6 +13,15 @@ export class ApiClientError extends Error {
   }
 }
 
+// Per-call request options. Mainly used by long-running endpoints (LLM
+// generation) that can blow past the global 30s axios timeout. Pass
+// `timeout: 0` to disable the client-side cutoff entirely so the request
+// resolves whenever the backend (or nginx) terminates it.
+export type ApiClientRequestOptions = {
+  timeout?: number;
+  signal?: AbortSignal;
+};
+
 export const apiClient = {
   async get<T>(path: string, params?: Record<string, string>): Promise<ApiResponse<T>> {
     try {
@@ -23,9 +32,16 @@ export const apiClient = {
     }
   },
 
-  async post<T>(path: string, body?: unknown): Promise<ApiResponse<T>> {
+  async post<T>(
+    path: string,
+    body?: unknown,
+    options?: ApiClientRequestOptions,
+  ): Promise<ApiResponse<T>> {
     try {
-      const response = await httpClient.post<T>(path, body);
+      const response = await httpClient.post<T>(path, body, {
+        timeout: options?.timeout,
+        signal: options?.signal,
+      });
       return { data: response.data, status: response.status };
     } catch (error) {
       throw toApiClientError(error);

--- a/apps/claw-frontend/src/services/shared/api-client.ts
+++ b/apps/claw-frontend/src/services/shared/api-client.ts
@@ -1,5 +1,5 @@
 import { httpClient } from '@/lib/http-client';
-import type { ApiResponse } from '@/types';
+import type { ApiClientRequestOptions, ApiResponse } from '@/types';
 
 export class ApiClientError extends Error {
   status: number;
@@ -12,15 +12,6 @@ export class ApiClientError extends Error {
     this.errors = params.errors;
   }
 }
-
-// Per-call request options. Mainly used by long-running endpoints (LLM
-// generation) that can blow past the global 30s axios timeout. Pass
-// `timeout: 0` to disable the client-side cutoff entirely so the request
-// resolves whenever the backend (or nginx) terminates it.
-export type ApiClientRequestOptions = {
-  timeout?: number;
-  signal?: AbortSignal;
-};
 
 export const apiClient = {
   async get<T>(path: string, params?: Record<string, string>): Promise<ApiResponse<T>> {

--- a/apps/claw-frontend/src/types/api.types.ts
+++ b/apps/claw-frontend/src/types/api.types.ts
@@ -18,3 +18,11 @@ export type ApiError = {
   status: number;
   errors?: Record<string, string[]>;
 };
+
+// Per-call request overrides for `apiClient.*`. Used by long-running endpoints
+// (LLM generation) that need to opt out of the default 30s axios timeout.
+// Pass `timeout: 0` to disable the client-side cutoff entirely.
+export type ApiClientRequestOptions = {
+  timeout?: number;
+  signal?: AbortSignal;
+};

--- a/apps/claw-frontend/src/types/index.ts
+++ b/apps/claw-frontend/src/types/index.ts
@@ -112,7 +112,12 @@ export type {
   DashboardPageResult,
 } from './dashboard.types';
 export type { ServiceHealthResult, AggregatedHealth } from './health.types';
-export type { ApiRequestConfig, ApiResponse, ApiError } from './api.types';
+export type {
+  ApiRequestConfig,
+  ApiResponse,
+  ApiError,
+  ApiClientRequestOptions,
+} from './api.types';
 export type {
   AuthStoreState,
   AuthStoreActions,

--- a/apps/claw-frontend/src/utilities/source-control.utility.ts
+++ b/apps/claw-frontend/src/utilities/source-control.utility.ts
@@ -1,5 +1,6 @@
 import type { TranslateFunction } from '../types/i18n.types';
 import type { PullRequestMetadata } from '../types/source-control.types';
+import type { WorkspaceObject } from '../types/workspace.types';
 
 function resolveStringField(
   metadata: Record<string, unknown>,
@@ -23,6 +24,31 @@ export function getPrStateLabel(state: string, t: TranslateFunction): string {
     return t('source_control.pr.state_closed');
   }
   return t('source_control.pr.state_open');
+}
+
+/**
+ * Dedupe `WorkspaceObject` rows by `(provider, externalId)`. Multiple
+ * connectors can sync the same upstream PR/issue and end up writing one row
+ * each (the rows are unique by `(connector_id, external_id)` in Postgres),
+ * so the unfiltered list query naturally returns N copies. We keep whichever
+ * copy has the most recent `externalUpdatedAt`.
+ */
+export function dedupeWorkspaceObjectsByProviderAndExternalId(
+  objects: WorkspaceObject[],
+): WorkspaceObject[] {
+  const seen = new Map<string, WorkspaceObject>();
+  for (const obj of objects) {
+    const key = `${obj.provider}:${obj.externalId}`;
+    const existing = seen.get(key);
+    if (existing === undefined) {
+      seen.set(key, obj);
+      continue;
+    }
+    const a = obj.externalUpdatedAt ?? '';
+    const b = existing.externalUpdatedAt ?? '';
+    if (a > b) seen.set(key, obj);
+  }
+  return Array.from(seen.values());
 }
 
 export function extractPrMetadata(metadata: Record<string, unknown>): PullRequestMetadata {

--- a/apps/claw-frontend/src/utilities/source-control.utility.ts
+++ b/apps/claw-frontend/src/utilities/source-control.utility.ts
@@ -46,7 +46,9 @@ export function dedupeWorkspaceObjectsByProviderAndExternalId(
     }
     const a = obj.externalUpdatedAt ?? '';
     const b = existing.externalUpdatedAt ?? '';
-    if (a > b) seen.set(key, obj);
+    if (a > b) {
+      seen.set(key, obj);
+    }
   }
   return Array.from(seen.values());
 }

--- a/apps/claw-frontend/src/utilities/stable-keys.utility.ts
+++ b/apps/claw-frontend/src/utilities/stable-keys.utility.ts
@@ -1,0 +1,20 @@
+/**
+ * Build stable, collision-free React keys for arrays whose elements may
+ * legitimately repeat (e.g. digest highlights aggregated from multiple
+ * sources). Returns one entry per input item: `{ key, item }`. Identical
+ * values get an `__n` suffix on later occurrences so each key is unique
+ * without falling back to the array index — keeps `react/no-array-index-key`
+ * happy and keeps reconciliation stable as long as the input order is.
+ */
+export function withDedupedKeys<T>(
+  items: T[],
+  getValue: (item: T) => string,
+): Array<{ key: string; item: T }> {
+  const seen = new Map<string, number>();
+  return items.map((item) => {
+    const value = getValue(item);
+    const n = (seen.get(value) ?? 0) + 1;
+    seen.set(value, n);
+    return { key: n === 1 ? value : `${value}__${n}`, item };
+  });
+}

--- a/apps/claw-workspace-service/src/app/config/app.config.ts
+++ b/apps/claw-workspace-service/src/app/config/app.config.ts
@@ -37,7 +37,7 @@ const appConfigSchema = z.object({
   OLLAMA_SERVICE_URL: z.string().min(1).default('http://ollama-service:4008'),
   CHAT_SERVICE_URL: z.string().min(1).default('http://chat-service:4002'),
   CONNECTOR_SERVICE_URL: z.string().min(1).default('http://connector-service:4003'),
-  AI_ACTION_REQUEST_TIMEOUT_MS: z.coerce.number().int().positive().default(120_000),
+  AI_ACTION_REQUEST_TIMEOUT_MS: z.coerce.number().int().positive().default(300_000),
   AI_ACTION_MODEL_RESOLVER_TTL_SECONDS: z.coerce.number().int().positive().default(300),
   // Stream 10 — AI action approval engine
   AI_ACTION_QUEUE_EXPIRY_HOURS: z.coerce.number().int().positive().default(24),

--- a/apps/claw-workspace-service/src/modules/ai-actions/managers/ai-action-execution.manager.ts
+++ b/apps/claw-workspace-service/src/modules/ai-actions/managers/ai-action-execution.manager.ts
@@ -1,6 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 
 import { AppConfig } from '../../../app/config/app.config';
+import { AiActionMode } from '../../../common/enums/ai-action-kind.enum';
+import { BusinessException } from '../../../common/errors/business.exception';
 import { AI_ACTION_FALLBACK_LOCAL_PROVIDER } from '../constants/ai-action-prompts.constants';
 import type {
   AiActionResult,
@@ -32,7 +34,11 @@ export class AiActionExecutionManager {
     });
     const { systemPrompt, userPrompt } = buildAiActionPrompt(input.actionKind, input.context);
     const started = Date.now();
-    const modelsToTry = await this.buildAttemptChain(resolution.primary, resolution.fallbackChain);
+    const modelsToTry = await this.buildAttemptChain(
+      resolution.primary,
+      resolution.fallbackChain,
+      resolution.mode,
+    );
     let lastError: Error | undefined;
     for (const model of modelsToTry) {
       try {
@@ -60,14 +66,57 @@ export class AiActionExecutionManager {
         );
       }
     }
-    throw lastError ?? new Error('All models in fallback chain exhausted');
+    // Surface upstream errors to the user with a 4xx (so the frontend's
+    // ApiClient doesn't mask the message as a generic 5xx). 422 is the
+    // closest match: the request was well-formed, but the upstream LLM
+    // provider couldn't fulfil it (subscription required, rate-limited,
+    // model unavailable, aborted by timeout, etc).
+    const userMessage = this.summariseUpstreamFailure(modelsToTry, lastError);
+    throw new BusinessException(
+      userMessage,
+      'AI_ACTION_UPSTREAM_FAILED',
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      { triedModels: modelsToTry.map((m) => `${m.provider}/${m.model}`) },
+    );
+  }
+
+  // Builds a one-line, user-readable explanation of why the AI call failed.
+  // Strips the JSON envelope our internal services add and pulls the
+  // upstream provider's message to the front so users see "this model
+  // requires a subscription" rather than "Internal server error".
+  private summariseUpstreamFailure(
+    modelsToTry: ModelChoice[],
+    lastError: Error | undefined,
+  ): string {
+    const tried = modelsToTry.map((m) => `${m.provider}/${m.model}`).join(', ');
+    if (lastError === undefined) {
+      return `All models exhausted with no error captured (tried: ${tried})`;
+    }
+    // Errors thrown by callCloudGenerate look like:
+    //   Cloud generation failed (HTTP 400): {"statusCode":400,"message":"...","code":"..."}
+    // Pull the inner `message` out so the user sees the upstream reason.
+    const match = lastError.message.match(/"message"\s*:\s*"([^"]+)"/);
+    const upstream = match ? match[1] : lastError.message;
+    if (modelsToTry.length === 1) {
+      return `${modelsToTry[0]?.provider}/${modelsToTry[0]?.model}: ${upstream}`;
+    }
+    return `All ${String(modelsToTry.length)} models failed. Last error from ${modelsToTry[modelsToTry.length - 1]?.provider}/${modelsToTry[modelsToTry.length - 1]?.model}: ${upstream}`;
   }
 
   private async buildAttemptChain(
     primary: ModelChoice,
     declaredFallbacks: ModelChoice[],
+    mode: AiActionMode,
   ): Promise<ModelChoice[]> {
     const chain = [primary, ...declaredFallbacks];
+    // MANUAL mode = user explicitly picked a model. Respect it: don't
+    // tack on a safety-net fallback that would silently swap to a slow
+    // local model (e.g. gemma3:27b) when the chosen model rate-limits or
+    // returns a subscription error. The upstream error should surface so
+    // the user can pick a different model — not get a 90s mystery wait.
+    if (mode === AiActionMode.MANUAL) {
+      return chain;
+    }
     const safetyNet = await this.resolver.resolveDefaults({ preferLocal: true });
     const additions: ModelChoice[] = [];
     if (safetyNet.primary !== null && !this.alreadyInChain(chain, safetyNet.primary)) {

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -239,6 +239,16 @@ http {
         }
 
         # --- Workspace Service ---
+        # AI action generation runs the LLM synchronously and routinely sits
+        # at 60-120s (slow local Ollama models). Must be declared BEFORE the
+        # generic /workspace block so nginx's longest-prefix match picks it.
+        location /api/v1/workspace/ai-actions/run {
+            set $workspace_backend http://workspace-service:4014;
+            proxy_pass $workspace_backend;
+            proxy_read_timeout 600s;
+            proxy_send_timeout 600s;
+        }
+
         location /api/v1/workspace {
             set $workspace_backend http://workspace-service:4014;
             proxy_pass $workspace_backend;


### PR DESCRIPTION
Three independent UI bugs surfaced together. (1) /workspace/source-control showed empty after sync. (2) AI action dialog crashed with TypeError on generatedBy.displayName. (3) Duplicate React keys in workspace digest. See commit message for details. Gates: typecheck 0, lint 0 errors, tests pass, build OK.