### PR TITLE
Potential fix for code scanning alert no. 24: Type confusion through parameter tampering

### DIFF
--- a/apps/claw-workspace-service/src/modules/webhooks/controllers/webhook-receiver.controller.ts
+++ b/apps/claw-workspace-service/src/modules/webhooks/controllers/webhook-receiver.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Get,
   Headers,
@@ -40,10 +41,21 @@ export class WebhookReceiverController {
     @Headers() headers: Record<string, string | string[] | undefined>,
     @Req() req: Request,
   ): Promise<WebhookReceiveResult> {
+    const requestBody = req.body;
+    let rawBody: Buffer;
+
+    if (Buffer.isBuffer(requestBody)) {
+      rawBody = requestBody;
+    } else if (typeof requestBody === 'string') {
+      rawBody = Buffer.from(requestBody, 'utf8');
+    } else {
+      throw new BadRequestException('Webhook body must be a raw buffer or string');
+    }
+
     return this.receiver.receive(
       parseWebhookProvider(providerRaw),
       connectorId === '_' ? null : connectorId,
-      Buffer.isBuffer(req.body) ? req.body : Buffer.from(JSON.stringify(req.body)),
+      rawBody,
       headers,
       (req.headers['x-forwarded-for'] as string | undefined) ?? req.ip ?? null,
     );


### PR DESCRIPTION
Potential fix for [https://github.com/ihabkhaled/ClawAI/security/code-scanning/24](https://github.com/ihabkhaled/ClawAI/security/code-scanning/24)

The best fix is to enforce strict runtime type checks in the controller before converting the request body into bytes:

- Accept only `Buffer` or `string` request bodies.
- Reject any other runtime type (arrays, objects, numbers, booleans, null/undefined) with a `BadRequestException`.
- Convert string bodies with `Buffer.from(body, 'utf8')`.
- Pass only validated buffer into `receiver.receive`.

This preserves existing functionality for expected inputs while preventing type confusion and unsafe coercion.

Change needed in:
- `apps/claw-workspace-service/src/modules/webhooks/controllers/webhook-receiver.controller.ts`
  - Add `BadRequestException` to Nest imports.
  - Replace inline `Buffer.isBuffer(req.body) ? ...` with explicit type-checked conversion logic inside `receive`.

No changes are required in the manager snippet because it already enforces `Buffer` type at its boundary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
