### PR TITLE
feat: show app version and harden production deployment

### DIFF
--- a/.ai/manifests/hashes.json
+++ b/.ai/manifests/hashes.json
@@ -18,7 +18,7 @@
     ".ai/manifests/rabbitmq-events.json": "40a57388",
     ".ai/manifests/repository.json": "047d93d0",
     ".ai/manifests/services.json": "9f6bc477",
-    ".ai/manifests/tests.json": "9d742e67",
+    ".ai/manifests/tests.json": "bbb57737",
     ".ai/manifests/workspace-dependency-graph.json": "7a3dff0f",
     ".ai/manifests/workspaces.json": "542f62ea",
     ".ai/packs/README.md": "2e64753b",

--- a/.ai/manifests/tests.json
+++ b/.ai/manifests/tests.json
@@ -58,7 +58,7 @@
     },
     "claw-frontend": {
       "runner": "vitest",
-      "testFiles": 273
+      "testFiles": 274
     },
     "claw-health-service": {
       "runner": "jest",
@@ -102,5 +102,5 @@
     }
   },
   "generated": true,
-  "total": 822
+  "total": 823
 }

--- a/apps/claw-frontend/src/app/(auth)/__tests__/layout.test.tsx
+++ b/apps/claw-frontend/src/app/(auth)/__tests__/layout.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import AuthLayout from '@/app/(auth)/layout';
+import { APP_VERSION } from '@/constants';
+import { Locale } from '@/enums/locale.enum';
+import { LocaleProvider } from '@/lib/i18n';
+import { en } from '@/lib/i18n/locales/en';
+
+describe('AuthLayout', () => {
+  it('shows the canonical app version on every authentication page', () => {
+    render(
+      <LocaleProvider initialLocale={Locale.EN} initialDictionary={en}>
+        <AuthLayout>
+          <main>Authentication page</main>
+        </AuthLayout>
+      </LocaleProvider>,
+    );
+
+    expect(screen.getByText(`Claw v${APP_VERSION}`)).toBeInTheDocument();
+  });
+});

--- a/apps/claw-frontend/src/app/(auth)/layout.tsx
+++ b/apps/claw-frontend/src/app/(auth)/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 
+import { AuthAppVersion } from '@/components/auth/auth-app-version';
+
 // Login/registration are never indexable — they carry no unique public
 // content and must not appear in search results. See src/middleware.ts for
 // the matching X-Robots-Tag header enforcement.
@@ -16,5 +18,10 @@ export default function AuthLayout({
 }: {
   children: React.ReactNode;
 }): React.ReactElement {
-  return <>{children}</>;
+  return (
+    <div className="relative min-h-dvh">
+      {children}
+      <AuthAppVersion />
+    </div>
+  );
 }

--- a/apps/claw-frontend/src/components/auth/auth-app-version.tsx
+++ b/apps/claw-frontend/src/components/auth/auth-app-version.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { APP_VERSION } from '@/constants';
+import { useTranslation } from '@/lib/i18n';
+
+export function AuthAppVersion(): React.ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <p className="text-muted-foreground absolute inset-x-0 bottom-3 text-center text-xs">
+      {t('common.brandVersion', { version: APP_VERSION })}
+    </p>
+  );
+}

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -68,7 +68,10 @@ happens to be by the time the SSH session runs.
    using `docker/docker-compose.prod.services.yml` **as committed at the
    target commit** (§2.3), checks out the target commit
    (`git checkout --detach`, then asserts `HEAD == target`), builds only the
-   affected services with at most two concurrent image builds, and recreates
+   affected services with at most two concurrent image builds. A failed build
+   is retried at most twice, with bounded backoff, only when its output proves
+   a transient registry/network failure such as `ECONNRESET`, `ETIMEDOUT`, or
+   temporary DNS failure. Deterministic failures are never retried. The script then recreates
    only those containers
    (`up -d --no-deps --no-build`, never `--remove-orphans`).
 9. Waits for every recreated service's Docker healthcheck to report
@@ -86,6 +89,16 @@ cannot start every service image build at once and starve the VPS or its SSH
 session. An operator may set the standard Compose variable
 `COMPOSE_PARALLEL_LIMIT` to an integer from `1` through `4` for a single deploy;
 values outside that safety range are rejected before the build starts.
+
+### 2.6 Frontend maintenance response
+
+The frontend catch-all intercepts upstream 502, 503, and 504 responses and
+returns `/etc/nginx/claw/public-tls/maintenance.html` as HTTP 503 with
+`Retry-After: 60` and `Cache-Control: no-store`. The self-contained page is
+tracked in the repository and arrives through the existing read-only nginx
+mount, so a validated `nginx -s reload` activates it without recreating the
+proxy. API routes are not intercepted and preserve their original status and
+response bodies.
 
 **Never**, under any normal deployment: `docker compose down`, `docker rm`,
 `docker volume rm`, `docker system prune`, `--remove-orphans`, `git clean`,

--- a/docs/features/ai-native-engineering-os/inventory.snapshot.json
+++ b/docs/features/ai-native-engineering-os/inventory.snapshot.json
@@ -8634,7 +8634,7 @@
       },
       "claw-frontend": {
         "runner": "vitest",
-        "testFiles": 273
+        "testFiles": 274
       },
       "claw-health-service": {
         "runner": "jest",
@@ -9390,7 +9390,7 @@
     "serviceCount": 18,
     "sharedPackageCount": 6,
     "staleClaimCount": 0,
-    "totalTestFiles": 822,
+    "totalTestFiles": 823,
     "workspaceCount": 25
   }
 }

--- a/docs/superpowers/plans/2026-08-13-production-auto-deploy-hardening.md
+++ b/docs/superpowers/plans/2026-08-13-production-auto-deploy-hardening.md
@@ -1,0 +1,20 @@
+# Production Auto-Deploy Hardening Implementation Plan
+
+**Goal:** Preserve the existing release deployment architecture, recover from transient build downloads, and serve a branded maintenance response while the frontend is unavailable.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-production-auto-deploy-hardening-design.md`
+
+## Constraints
+
+- Never edit tracked files directly on `/srv/clawai`.
+- Deploy only the exact release SHA supplied by GitHub Actions.
+- Never touch database containers, volumes, or reverse migrations.
+- Never bypass Git hooks or expose secrets.
+
+## Tasks
+
+1. Verify the existing CI-to-release-to-deploy chain and exact-SHA tests remain green.
+2. Add red tests and implement at most two retries for recognized transient Docker build network errors.
+3. Add red tests, a self-contained ClawAI maintenance page, and frontend-only nginx 502/503/504 interception through the existing read-only mount.
+4. Validate focused tests, shell/nginx syntax, affected workspaces, generated artifacts, commit hooks, and PR checks.
+5. After merge, observe automatic deployment and verify production state over read-only SSH commands.

--- a/docs/superpowers/specs/2026-08-13-production-auto-deploy-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-13-production-auto-deploy-hardening-design.md
@@ -1,0 +1,42 @@
+# Production Auto-Deploy Hardening Design
+
+## Objective
+
+Every successful CI and release run for a push to `main` must deploy the exact release commit to `/srv/clawai`. The server checkout remains free of tracked local edits, containers are recreated only after successful builds, and nginx serves a ClawAI-themed maintenance page when the frontend is temporarily unavailable.
+
+## Evidence and root cause
+
+Production run `31684025240` targeted release commit `b94fd48a`, fetched and checked it out, then stopped safely when the frontend Docker build received npm registry `ECONNRESET`. Containers and `.deploy/deployed-sha` correctly stayed on `707b2a9c`. This proves the existing CI-to-release-to-deploy trigger and exact-SHA synchronization work; the missing behavior is resilience to transient build-network failures.
+
+## Architecture
+
+### Trigger and source synchronization
+
+Preserve the existing successful-CI to release to production-deploy chain. The release workflow passes its exact pushed release commit SHA into the reusable deployment workflow. On the server, `deploy-prod.sh` fetches origin and performs a detached exact-SHA checkout. This provides deterministic synchronization without a merge-prone plain `git pull` or any server-side code edits.
+
+### Build resilience
+
+Retry the complete Docker Compose build at most twice only when captured output contains a recognized transient network failure (`ECONNRESET`, `ETIMEDOUT`, temporary DNS/registry connectivity errors). Backoff is bounded. Compilation, configuration, migration, disk, and other deterministic failures exit immediately. Containers are never recreated until a build succeeds.
+
+### Maintenance fallback
+
+Intercept frontend upstream 502, 503, and 504 responses only in the frontend catch-all. Internally serve a responsive `maintenance.html` from the existing read-only nginx `public-tls` mount with HTTP 503, `Retry-After: 60`, and `Cache-Control: no-store`. API routes retain their existing behavior. The page uses ClawAI's dark navy/cyan theme, accessible contrast, and no external dependencies.
+
+### Server integrity and verification
+
+Never edit tracked production files through SSH. Deployment continues to reject tracked server changes. Success requires target checkout equality, affected-container health, and atomic `.deploy/deployed-sha` recording. After merge, observe the automatic release/deployment and verify clean tracked state, matching `HEAD` and recorded SHA, healthy containers, and the live application version.
+
+## Failure behavior
+
+- SSH transport failures retain existing bounded retries.
+- Transient registry/build-network failures receive bounded retries.
+- Deterministic build failures stop before container recreation.
+- Failed frontend requests receive the maintenance page with HTTP 503.
+- Database and persistent infrastructure containers remain outside automatic deployment.
+
+## Tests
+
+- Existing workflow tests cover successful CI, release, and exact-SHA deployment wiring.
+- Deploy-script tests cover bounded transient-only retries and destructive-operation guards.
+- Nginx tests cover frontend-only interception, headers, branding, and accessibility essentials.
+- Knowledge, inventory, affected-workspace, nginx syntax, and normal Git hooks remain required.

--- a/infra/nginx/locations.conf
+++ b/infra/nginx/locations.conf
@@ -465,8 +465,19 @@
     location / {
         set $frontend_backend http://claw-frontend:3000;
         proxy_pass $frontend_backend;
+        proxy_intercept_errors on;
+        error_page 502 503 504 =503 /maintenance.html;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_read_timeout 86400;
+    }
+
+    location = /maintenance.html {
+        internal;
+        default_type text/html;
+        root /etc/nginx/claw/public-tls;
+        try_files /maintenance.html =503;
+        add_header Retry-After "60" always;
+        add_header Cache-Control "no-store" always;
     }

--- a/infra/nginx/public-tls/maintenance.html
+++ b/infra/nginx/public-tls/maintenance.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>ClawAI | Temporarily unavailable</title>
+    <style>
+      :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+      * { box-sizing: border-box; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; color: #eaf7ff; background: radial-gradient(circle at 50% 0%, #0d3448 0, #07141f 42%, #03080f 100%); }
+      main { width: min(100%, 640px); padding: clamp(28px, 7vw, 56px); text-align: center; border: 1px solid rgba(61, 203, 255, .25); border-radius: 24px; background: rgba(4, 17, 27, .88); box-shadow: 0 24px 80px rgba(0, 0, 0, .45); }
+      .brand { display: inline-flex; align-items: center; gap: 10px; color: #64d8ff; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+      .mark { display: grid; place-items: center; width: 38px; height: 38px; border: 1px solid #37c8ff; border-radius: 12px; background: rgba(55, 200, 255, .1); font-size: 20px; }
+      h1 { margin: 28px 0 12px; font-size: clamp(2rem, 7vw, 3.5rem); line-height: 1.05; letter-spacing: -.04em; }
+      p { margin: 0 auto; max-width: 48ch; color: #acc5d3; font-size: 1.05rem; line-height: 1.7; }
+      .status { display: inline-flex; align-items: center; gap: 9px; margin-top: 28px; padding: 9px 14px; border-radius: 999px; color: #b8edff; background: rgba(55, 200, 255, .09); font-size: .86rem; }
+      .dot { width: 8px; height: 8px; border-radius: 50%; background: #45d6ff; box-shadow: 0 0 16px #45d6ff; }
+    </style>
+  </head>
+  <body>
+    <main aria-labelledby="maintenance-title">
+      <div class="brand"><span class="mark" aria-hidden="true">C</span>ClawAI</div>
+      <h1 id="maintenance-title">We’ll be right back</h1>
+      <p>We’re deploying an update or restoring the service. Your data is safe. Please try again in a minute.</p>
+      <div class="status" role="status"><span class="dot" aria-hidden="true"></span>Temporary maintenance</div>
+    </main>
+  </body>
+</html>

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -89,6 +89,7 @@ DEP_GRAPH_REL=".ai/manifests/workspace-dependency-graph.json"
 LOCK_WAIT_SECONDS="${CLAW_DEPLOY_LOCK_WAIT:-1800}"
 HEALTH_TIMEOUT_SECONDS="${CLAW_DEPLOY_HEALTH_TIMEOUT:-420}"
 BUILD_PARALLEL_LIMIT="${COMPOSE_PARALLEL_LIMIT:-2}"
+BUILD_RETRY_DELAYS=(10 30)
 
 # Files that reach EVERY application image. Each service Dockerfile does
 # `COPY package.json`, `COPY .npmrc` and `COPY packages/`, and the build context
@@ -145,6 +146,38 @@ die() {
   err "DEPLOYMENT FAILED: $*"
   err ""
   exit 1
+}
+
+build_services() {
+  local output_file="$TMP_DIR/build-output"
+  local attempt status delay
+
+  for attempt in 1 2 3; do
+    : >"$output_file"
+    set +e
+    COMPOSE_PARALLEL_LIMIT="$BUILD_PARALLEL_LIMIT" compose build "${PLAN_SERVICES[@]}" \
+      2>&1 | tee "$output_file"
+    status="${PIPESTATUS[0]}"
+    set -e
+
+    if [ "$status" -eq 0 ]; then
+      return 0
+    fi
+
+    if ! grep -Eqi 'ECONNRESET|ETIMEDOUT|EAI_AGAIN|network (is )?unreachable|temporary failure in name resolution|TLS handshake timeout|connection reset by peer' "$output_file"; then
+      err "docker compose build failed with a non-transient error; refusing to retry."
+      return "$status"
+    fi
+
+    if [ "$attempt" -eq 3 ]; then
+      err "docker compose build exhausted 3 attempts after transient network failures."
+      return "$status"
+    fi
+
+    delay="${BUILD_RETRY_DELAYS[$((attempt - 1))]}"
+    err "docker compose build hit a transient network failure; retrying in ${delay}s."
+    sleep "$delay"
+  done
 }
 
 usage() {
@@ -387,7 +420,7 @@ compute_plan() {
         esac
         continue
         ;;
-      infra/nginx/nginx.conf | infra/nginx/locations.conf)
+      infra/nginx/nginx.conf | infra/nginx/locations.conf | infra/nginx/public-tls/maintenance.html)
         PLAN_NGINX_RELOAD=1
         continue
         ;;
@@ -940,7 +973,7 @@ main() {
   # release can fan out to all application services and exhaust VPS CPU long
   # enough for the controlling SSH connection to time out. Keep the default
   # deliberately conservative; operators may choose a value from 1 to 4.
-  if ! COMPOSE_PARALLEL_LIMIT="$BUILD_PARALLEL_LIMIT" compose build "${PLAN_SERVICES[@]}"; then
+  if ! build_services; then
     err ""
     err "Build failed. No container was recreated; production is still serving"
     err "the previously deployed commit ${old_sha:-<unknown>}."

--- a/tools/__tests__/deploy-prod.test.mjs
+++ b/tools/__tests__/deploy-prod.test.mjs
@@ -57,6 +57,21 @@ test('deploy-prod.sh bounds Docker Compose build concurrency with a conservative
   assert.match(script, /must be an integer from 1 to 4/u);
 });
 
+test('deploy-prod.sh retries only transient build-network failures with bounded backoff', () => {
+  assert.match(script, /BUILD_RETRY_DELAYS=\(10 30\)/u);
+  assert.match(script, /for attempt in 1 2 3/u);
+  assert.match(script, /ECONNRESET\|ETIMEDOUT\|EAI_AGAIN/u);
+  assert.match(script, /docker compose build failed with a non-transient error/u);
+  assert.match(script, /transient network failure; retrying in/u);
+});
+
+test('deploy-prod.sh reloads nginx when the tracked maintenance asset changes', () => {
+  assert.match(
+    script,
+    /infra\/nginx\/nginx\.conf \| infra\/nginx\/locations\.conf \| infra\/nginx\/public-tls\/maintenance\.html/u,
+  );
+});
+
 test('deploy-prod.sh writes the deployed SHA only via the atomic record_deployment helper', () => {
   const writesToStateFile = [...script.matchAll(/>\s*"?\$STATE_FILE"?(?!\.tmp)/gu)];
   assert.deepEqual(writesToStateFile, [], 'a direct, non-atomic write to $STATE_FILE was found');

--- a/tools/__tests__/nginx-maintenance.test.mjs
+++ b/tools/__tests__/nginx-maintenance.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+import { repoPath } from '../lib/repo.mjs';
+
+const locations = readFileSync(repoPath('infra/nginx/locations.conf'), 'utf8');
+const compose = readFileSync(repoPath('docker/docker-compose.prod.services.yml'), 'utf8');
+const maintenance = readFileSync(repoPath('infra/nginx/public-tls/maintenance.html'), 'utf8');
+
+test('frontend failures use an internal 503 maintenance response', () => {
+  const frontend = locations.slice(locations.lastIndexOf('location / {'));
+  assert.match(frontend, /proxy_intercept_errors on;/u);
+  assert.match(frontend, /error_page 502 503 504 =503 \/maintenance\.html;/u);
+  assert.match(frontend, /location = \/maintenance\.html/u);
+  assert.match(frontend, /internal;/u);
+  assert.match(frontend, /default_type text\/html;/u);
+  assert.match(frontend, /add_header Retry-After "60" always;/u);
+});
+
+test('production nginx mounts the maintenance asset read-only', () => {
+  assert.match(compose, /\.\.\/infra\/nginx\/public-tls:\/etc\/nginx\/claw\/public-tls:ro/u);
+});
+
+test('maintenance page is self-contained, branded, responsive, and accessible', () => {
+  assert.match(maintenance, /<meta name="viewport"/u);
+  assert.match(maintenance, /<title>ClawAI \| Temporarily unavailable<\/title>/u);
+  assert.match(maintenance, /<h1[^>]*>We’ll be right back<\/h1>/u);
+  assert.match(maintenance, /ClawAI/u);
+  assert.match(maintenance, /role="status"/u);
+  assert.doesNotMatch(maintenance, /https?:\/\//u);
+});


### PR DESCRIPTION
## Summary

- show the canonical application version on the shared authentication layout, covering login, registration, and email verification without page-level duplication
- harden the existing CI -> release -> exact-SHA SSH production deployment against transient registry/network build failures
- serve a self-contained ClawAI-themed HTTP 503 maintenance screen when only the frontend upstream returns 502, 503, or 504
- preserve API error behavior, database containers, volumes, and the clean production checkout invariant

## Root cause and production evidence

Production workflow run `31684025240` successfully reached `92.205.176.113`, fetched and checked out release commit `b94fd48a`, then the frontend Docker build failed on npm `ECONNRESET`. The deployment correctly did not recreate containers and did not advance `.deploy/deployed-sha`, which remained `707b2a9c`. The tracked server checkout was clean and all currently running containers were healthy.

The workflow trigger and exact-SHA synchronization were therefore left unchanged. The fix retries the Compose build at most twice only for recognized transient network errors, with 10s/30s bounded backoff. Deterministic failures still stop immediately before container recreation.

## Maintenance behavior

- frontend catch-all intercepts upstream 502/503/504 only
- internally serves repository-owned `infra/nginx/public-tls/maintenance.html`
- returns HTTP 503 with `Retry-After: 60` and `Cache-Control: no-store`
- uses the existing read-only nginx mount, so deployment validates and reloads nginx without server-side edits
- API routes preserve their original errors and response bodies

## Validation

- TDD regression tests observed failing before the retry and maintenance implementations
- deployment/workflow suite: 43 passed, 1 Windows-only Unix rehearsal skipped
- full tooling pre-push suite: 156 passed, 1 Windows-only rehearsal skipped
- frontend typecheck passed
- frontend lint passed with 0 errors (2 pre-existing RegExp warnings)
- frontend tests passed: 268 files, 1,691 tests
- frontend production build passed: 116 routes
- containerized `nginx -t` passed with the repository configuration
- knowledge verification and inventory audit passed
- normal pre-commit and pre-push hooks passed; no hook bypass was used

## Deployment after merge

The existing successful-CI -> release -> reusable production-deploy chain will deploy the exact newly created release SHA. No tracked files were edited on the server. After merge, the deployment run should be observed and production verified for a clean checkout, matching recorded SHA, healthy containers, live app version, and maintenance fallback behavior.

## Branch basis

Rebased onto `main` after PR #155 was merged.