### PR TITLE
fix(frontend): use exact plan limit labels

### DIFF
--- a/apps/claw-frontend/src/components/marketing/home/__tests__/plan-tier-card.test.tsx
+++ b/apps/claw-frontend/src/components/marketing/home/__tests__/plan-tier-card.test.tsx
@@ -57,8 +57,10 @@ describe('PlanTierCard', () => {
   it('shows every token and resource limit on the public plan', () => {
     render(<PlanTierCard plan={{ ...PLAN, weeklyTokenQuota: 20_000 }} isYearly={false} />);
 
+    expect(screen.getByText('userPlan.dailyLimitLabel')).toBeInTheDocument();
     expect(screen.getByText('adminPlans.form.weeklyTokenQuota')).toBeInTheDocument();
-    expect(screen.getByText('adminPlans.form.maxChatsPerDay')).toBeInTheDocument();
+    expect(screen.getByText('userPlan.monthlyLimitLabel')).toBeInTheDocument();
+    expect(screen.getByText('userPlan.chatsLimitLabel')).toBeInTheDocument();
     expect(screen.getByText('adminPlans.form.maxMessagesPerDay')).toBeInTheDocument();
     expect(screen.getByText('adminPlans.form.maxWorkspaceConnections')).toBeInTheDocument();
     expect(screen.getByText('adminPlans.form.maxContextPacks')).toBeInTheDocument();

--- a/apps/claw-frontend/src/components/marketing/home/plan-tier-card.tsx
+++ b/apps/claw-frontend/src/components/marketing/home/plan-tier-card.tsx
@@ -63,7 +63,7 @@ export function PlanTierCard({ plan, isYearly }: PublicPlanCardProps): React.Rea
 
       <dl className="text-muted-foreground mt-4 space-y-1 text-xs">
         <div className="flex justify-between gap-2">
-          <dt>{t('marketing.pricing.dailyTokens')}</dt>
+          <dt>{t('userPlan.dailyLimitLabel')}</dt>
           <dd className="text-foreground font-medium">
             {formatPlanQuota(plan.dailyTokenQuota, disabled, unlimited, locale)}
           </dd>
@@ -75,13 +75,13 @@ export function PlanTierCard({ plan, isYearly }: PublicPlanCardProps): React.Rea
           </dd>
         </div>
         <div className="flex justify-between gap-2">
-          <dt>{t('marketing.pricing.monthlyTokens')}</dt>
+          <dt>{t('userPlan.monthlyLimitLabel')}</dt>
           <dd className="text-foreground font-medium">
             {formatPlanQuota(plan.monthlyTokenQuota, disabled, unlimited, locale)}
           </dd>
         </div>
         <div className="flex justify-between gap-2">
-          <dt>{t('adminPlans.form.maxChatsPerDay')}</dt>
+          <dt>{t('userPlan.chatsLimitLabel')}</dt>
           <dd className="text-foreground font-medium">
             {formatPlanQuota(plan.maxChatsPerDay, disabled, unlimited, locale)}
           </dd>


### PR DESCRIPTION
## Summary
- use exact translated plan-limit labels on public pricing
- align pricing with My Plan wording for daily tokens, monthly tokens, and chats per day

## Release notes
### Fixed
- Public pricing no longer labels token limits as generic daily/monthly allowances.
- Public pricing now shows `Daily tokens`, `Monthly tokens`, and `Chats per day` using translation keys already present in all supported locales.

## Production evidence
Live Chromium against v1.28.1 showed every resource limit and all nine Orchestration Labs, but exposed the three inconsistent labels fixed here.

## Verification
- PlanTierCard: 5/5 tests passed
- Frontend typecheck passed
- Frontend lint passed with zero errors
- Knowledge integrity and inventory freshness passed