### PR TITLE
fix(auth): return the account id from the VS Code authorization exchange

### DIFF
--- a/apps/claw-auth-service/src/modules/auth/services/__tests__/vscode-authorization.service.spec.ts
+++ b/apps/claw-auth-service/src/modules/auth/services/__tests__/vscode-authorization.service.spec.ts
@@ -80,7 +80,13 @@ describe('VscodeAuthorizationService', () => {
     const approval = await service.approve(initialized.requestId, 'user-1');
     const code = new URL(approval.redirectUri).searchParams.get('code');
 
-    await expect(service.exchange(code ?? '', verifier)).resolves.toEqual({ tokens });
+    // The account id rides with the tokens so the extension can tell the SAME
+    // user authorizing in a second window from a different account taking over
+    // the shared session slot. Without it, a second window logged the first out.
+    await expect(service.exchange(code ?? '', verifier)).resolves.toEqual({
+      tokens,
+      accountId: 'user-1',
+    });
     await expect(service.exchange(code ?? '', verifier)).rejects.toBeInstanceOf(
       UnauthorizedException,
     );

--- a/apps/claw-auth-service/src/modules/auth/services/vscode-authorization.service.ts
+++ b/apps/claw-auth-service/src/modules/auth/services/vscode-authorization.service.ts
@@ -115,7 +115,10 @@ export class VscodeAuthorizationService {
       kind: VSCODE_AUTHORIZATION_CLIENT_KIND,
       name: record.clientName,
     });
-    return { tokens };
+    // The account travels with the tokens so the extension can tell a second
+    // window of the SAME user from a different account taking over the shared
+    // session slot. Only the id: nothing here needs the email or the name.
+    return { tokens, accountId: user.id };
   }
 
   private async getRequest(requestId: string): Promise<VscodeAuthorizationRequestRecord> {

--- a/apps/claw-auth-service/src/modules/auth/types/vscode-authorization.types.ts
+++ b/apps/claw-auth-service/src/modules/auth/types/vscode-authorization.types.ts
@@ -30,4 +30,14 @@ export interface VscodeAuthorizationApproval {
 
 export interface VscodeAuthorizationExchangeResult {
   tokens: TokenPair;
+  /**
+   * Which account these tokens belong to.
+   *
+   * The extension stores one session per backend origin and shares it across
+   * windows. Without an account identity it cannot tell "the same user
+   * re-authorized in another window", which it should adopt silently, from "a
+   * different account now owns this slot", which it must refuse. It assumed the
+   * second, so opening a second window logged the first one out.
+   */
+  accountId: string;
 }


### PR DESCRIPTION
## Problem

The coding-agent extension stores **one session per backend origin** and shares it across every VS Code window. Binding refused any session id it had not already seen:

```js
if (current !== null && current !== incoming) throw new BackendSessionChangedError();
```

So signing in from a second window rotated the shared record, and the first window's next bind threw and dropped it to the Connect gate with its queued message lost. Reconnecting that window then evicted the second. Two windows could never both hold a session — parallel agent work was impossible, and it presented as a random logout rather than a rule.

## Why the backend has to change

The extension needs to distinguish two cases that look identical from the session id alone:

- the **same user** signed in from another window → adopt the rotation
- a **different account** took the slot → refuse, because continuing would run one person's agent against another person's entitlements

That needs an account identity on the record. The exchange already loads the user to check the account is active, so the id is in hand — returning it avoids a second round trip to the profile endpoint.

Only the id. Nothing in the binding decision needs the email or the name, and a narrower payload is the right default for a token exchange.

## Change

`POST /auth/vscode/authorize/exchange` now returns `{ tokens, accountId }`. Additive — callers reading only `tokens` are unaffected.

## Validation

`vscode-authorization.service.spec.ts` — 3 tests pass. The exchange assertion now pins the account id, so the field cannot be dropped silently.

## Paired change

Extension side is coding-agent `0.63.4` (ihabkhaled/ClawAI-Coding-Agent, branch `fix/coding-agent-tool-round-ceiling`): the account, not the session id, becomes what may not change underneath a client. Same-account rotations are adopted, a genuine account change still fails closed, and records written before accounts existed keep the old strict behaviour rather than being adopted on faith. 1089 unit tests pass.

**Verified live:** two `serve-web` windows against one backend, both reporting connected at the same time — the second adopting the session without a second authorization, the first left untouched. Before this pair, opening the second window logged the first out every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)