### PR TITLE
fix: routing-service crashed under load, and marketing pages failed contrast in both themes

### DIFF
--- a/apps/claw-frontend/src/app/globals.css
+++ b/apps/claw-frontend/src/app/globals.css
@@ -1239,6 +1239,27 @@
     line-height: 1.6;
   }
 
+  /* The CTA is an INVERTED panel — its ground is `--editorial-ink`, not
+   * `--editorial-paper`. So any child that re-sets `color` has to take that
+   * colour from the inverted set too. `--editorial-signal` and
+   * `--editorial-graphite` are both tuned for a paper ground, and on ink they
+   * land at 3.4:1 and 3.0:1 in light mode, 2.3:1 and 1.8:1 in dark. Both
+   * themes fail WCAG AA; dark merely fails louder, which is why Lighthouse
+   * reported it first.
+   *
+   * The compare pages never hit this: they put bare text in the panel and let
+   * it inherit the panel's own colour. Only the learn and integration topic
+   * pages nest `__verdict-label` + `__body` inside, so only those 32 URLs
+   * failed the gate.
+   */
+  .editorial-comparison__cta .editorial-comparison__verdict-label {
+    color: var(--editorial-paper);
+  }
+
+  .editorial-comparison__cta .editorial-comparison__body {
+    color: color-mix(in srgb, var(--editorial-paper) 85%, var(--editorial-ink));
+  }
+
   .editorial-comparison__cta-actions {
     display: flex;
     flex-wrap: wrap;

--- a/apps/claw-routing-service/src/modules/routing/__tests__/routing-education.repository.spec.ts
+++ b/apps/claw-routing-service/src/modules/routing/__tests__/routing-education.repository.spec.ts
@@ -71,6 +71,7 @@ const buildRepo = (): {
     routerModelProfile: { deleteMany: jest.Mock; createMany: jest.Mock };
     routerTopicProfile: { deleteMany: jest.Mock; createMany: jest.Mock };
     routerWorkspacePrior: { findUnique: jest.Mock; upsert: jest.Mock };
+    $queryRaw: jest.Mock;
     $transaction: jest.Mock;
   };
 } => {
@@ -106,6 +107,9 @@ const buildRepo = (): {
     routerModelProfile,
     routerTopicProfile,
     routerWorkspacePrior,
+    // The advisory lock that serialises the replace. Returns a resolved value
+    // so it can sit inside the $transaction array like any PrismaPromise.
+    $queryRaw: jest.fn().mockResolvedValue([{ pg_advisory_xact_lock: '' }]),
     // Mirrors Prisma's array-form $transaction: resolve each already-created
     // PrismaPromise and return the results in order, so commitCalibrationBatch
     // can destructure the created snapshot out of the batch.
@@ -154,6 +158,37 @@ describe('RoutingEducationRepository.commitCalibrationBatch', () => {
     expect(prisma.routerTopicProfile.deleteMany).toHaveBeenCalledTimes(1);
     expect(snapshot.version).toBe('calibration-2');
   });
+
+  it('takes the advisory lock as the FIRST statement in the transaction', async () => {
+    // Regression guard. Without this lock, two concurrent rebuilds interleave:
+    // the second transaction's DELETE snapshot predates the first's COMMIT, so
+    // it removes only the rows it can see and its INSERT then violates
+    // `router_model_profiles_provider_model_task_family_topic_key_key`. The
+    // P2002 is an unhandled rejection that kills routing-service outright, and
+    // `rebuildCalibrationSnapshot()` runs after EVERY routing outcome, so the
+    // exposure is every pair of concurrent generations. Observed twice in a
+    // long-thread stress run on 2026-08-30.
+    //
+    // Order is the whole point: a lock taken after the DELETE would let the
+    // race happen before it ever blocks anything.
+    const { repository, prisma } = buildRepo();
+
+    await repository.commitCalibrationBatch({
+      version: 'calibration-3',
+      windowDays: 30,
+      summary: { decisionsAnalyzed: 1 },
+      promptHints: { bestModelsByTaskFamily: [] },
+      modelProfiles: [modelProfileRow()],
+      topicProfiles: [topicProfileRow()],
+      modelProfileRows: [modelProfileRow()],
+      topicProfileRows: [topicProfileRow()],
+    });
+
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+    const [operations] = prisma.$transaction.mock.calls[0] as [unknown[]];
+    expect(operations).toHaveLength(7);
+    expect(operations[0]).toBe(prisma.$queryRaw.mock.results[0]?.value);
+  });
 });
 
 describe('RoutingEducationRepository.restoreCalibrationSnapshot', () => {
@@ -167,6 +202,9 @@ describe('RoutingEducationRepository.restoreCalibrationSnapshot', () => {
     });
 
     expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    // The rollback path replaces the same tables the same way, so it is exposed
+    // to the same race and takes the same lock first.
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
     expect(prisma.routingCalibrationSnapshot.updateMany).toHaveBeenNthCalledWith(1, {
       data: { active: false },
       where: { active: true },

--- a/apps/claw-routing-service/src/modules/routing/constants/routing-education.constants.ts
+++ b/apps/claw-routing-service/src/modules/routing/constants/routing-education.constants.ts
@@ -65,3 +65,37 @@ export const WORKSPACE_PRIOR_BLEND_WEIGHT = 0.15;
  * never touches at all).
  */
 export const MAX_WORKSPACE_PRIOR_NUDGE = 0.1;
+
+/**
+ * Advisory-lock key that serialises calibration commits.
+ *
+ * `commitCalibrationBatch` and `restoreCalibrationSnapshot` both replace the
+ * whole live profile set with `deleteMany()` followed by `createMany()`. That
+ * pair is not safe to run concurrently under READ COMMITTED: if the second
+ * transaction's DELETE takes its snapshot before the first COMMITs, it removes
+ * only the rows it can see, never observes the rows the first is inserting, and
+ * its own INSERT then violates
+ * `router_model_profiles_provider_model_task_family_topic_key_key`.
+ *
+ * That is not hypothetical. `rebuildCalibrationSnapshot()` runs on EVERY
+ * routing outcome, so every pair of concurrent generations is an opportunity,
+ * and the resulting P2002 is an unhandled rejection that kills the process —
+ * routing-service down, `/routing/models` 502, no message routable at all.
+ * Reproduced twice on 2026-08-30 under a long-thread stress run.
+ *
+ * The window widens as history accumulates: `findEducationWindow` returns a
+ * growing set of decisions, so the transaction takes longer the more the system
+ * has been used. It survived 24 concurrent generations on a young database and
+ * crashed reliably after ~1,400, which is why load testing a fresh install does
+ * not surface it.
+ *
+ * A transaction-scoped advisory lock makes the replace atomic against other
+ * writers and is released automatically on COMMIT or ROLLBACK, so a crashed
+ * transaction cannot strand it.
+ *
+ * Next in routing-service's 740_040_00N advisory-lock block (001 = deployment
+ * seed, 002 = router chain seed, 003 = model cost seed). The value must stay
+ * stable; it only has to be distinct from the other advisory locks held against
+ * this database.
+ */
+export const CALIBRATION_COMMIT_LOCK_KEY = 740_040_004;

--- a/apps/claw-routing-service/src/modules/routing/repositories/routing-education.repository.ts
+++ b/apps/claw-routing-service/src/modules/routing/repositories/routing-education.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
+  Prisma,
   type RouterModelProfile,
   type RouterTopicProfile,
   type RouterWorkspacePrior,
@@ -8,6 +9,7 @@ import {
   type RoutingOutcomeRecord,
 } from '../../../generated/prisma';
 import { PrismaService } from '../../../infrastructure/database/prisma/prisma.service';
+import { CALIBRATION_COMMIT_LOCK_KEY } from '../constants/routing-education.constants';
 import type {
   CommitCalibrationBatchInput,
   CreateRoutingFeedbackInput,
@@ -143,7 +145,14 @@ export class RoutingEducationRepository {
     input: CommitCalibrationBatchInput,
   ): Promise<RoutingCalibrationSnapshot> {
     const now = new Date();
-    const [, snapshot] = await this.prisma.$transaction([
+    // Serialise the whole replace. See CALIBRATION_COMMIT_LOCK_KEY: the
+    // delete-then-insert below races itself under concurrent rebuilds and the
+    // resulting P2002 takes the process down. The lock is transaction-scoped,
+    // so it is released on COMMIT or ROLLBACK without any cleanup path.
+    const [, , snapshot] = await this.prisma.$transaction([
+      this.prisma.$queryRaw(
+        Prisma.sql`SELECT pg_advisory_xact_lock(${CALIBRATION_COMMIT_LOCK_KEY})::text`,
+      ),
       this.prisma.routingCalibrationSnapshot.updateMany({
         data: { active: false },
         where: { active: true },
@@ -184,7 +193,12 @@ export class RoutingEducationRepository {
     topicProfileRows: RouterTopicProfileRecord[];
   }): Promise<void> {
     const now = new Date();
+    // Same lock as the commit path: a rollback replaces the same live tables
+    // the same way, so it must not interleave with a concurrent rebuild either.
     await this.prisma.$transaction([
+      this.prisma.$queryRaw(
+        Prisma.sql`SELECT pg_advisory_xact_lock(${CALIBRATION_COMMIT_LOCK_KEY})::text`,
+      ),
       this.prisma.routingCalibrationSnapshot.updateMany({
         data: { active: false },
         where: { active: true },

--- a/scripts/qa-lab/client.mjs
+++ b/scripts/qa-lab/client.mjs
@@ -20,8 +20,14 @@ export const ALLOW_METERED = false;
 let token = null;
 let tokenAt = 0;
 
+// Whoever the process is currently acting as. Kept separate from EMAIL /
+// PASSWORD so the silent token refresh below renews the ACTIVE identity rather
+// than snapping back to the lab account mid-run.
+let activeEmail = EMAIL;
+let activePassword = PASSWORD;
+
 export async function login() {
-  if (EMAIL.length === 0 || PASSWORD.length === 0) {
+  if (activeEmail.length === 0 || activePassword.length === 0) {
     throw new Error(
       'QA_LAB_EMAIL and QA_LAB_PASSWORD must be set. See skills/audit-conversational-context.md.',
     );
@@ -29,13 +35,54 @@ export async function login() {
   const res = await fetch(`${BASE}/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email: EMAIL, password: PASSWORD }),
+    body: JSON.stringify({ email: activeEmail, password: activePassword }),
   });
   if (!res.ok) throw new Error(`login failed ${res.status} ${await res.text()}`);
   const body = await res.json();
   token = body.tokens.accessToken;
   tokenAt = Date.now();
   return body.user;
+}
+
+/**
+ * Act as a different user for every subsequent call.
+ *
+ * Memories are USER-scoped and are injected into every thread that user owns,
+ * so an account that has accumulated fixtures from earlier runs quietly
+ * contaminates later ones: a stored "the internal project codename is ORCHID-…"
+ * competes with the codename the scenario seeds in the thread, and the model
+ * picks one. Measured on the shared lab account — three recall probes at
+ * distances 4, 24 and 56 all failed at exactly the same rate, which is the
+ * signature of a constant competing fact rather than of context loss.
+ *
+ * A long run therefore belongs on its own fresh account, where the only thing
+ * in scope is the conversation being measured.
+ */
+export async function loginAs(email, password) {
+  activeEmail = email;
+  activePassword = password;
+  token = null;
+  tokenAt = 0;
+  return login();
+}
+
+/** Mint a brand-new empty account (admin credentials required). */
+export async function createIsolatedUser(tag) {
+  const suffix = `${tag}${Date.now().toString(36)}`;
+  const account = {
+    email: `qa-${suffix}@claw.local`,
+    username: `qa${suffix}`.replace(/[^a-z0-9]/gi, '').slice(0, 28),
+    password: 'QaIsolated123!',
+    firstName: 'QA',
+    lastName: 'Isolated',
+  };
+  await login();
+  const created = await api('POST', '/users', account);
+  if (!created.ok) {
+    throw new Error(`createIsolatedUser failed ${created.status} ${JSON.stringify(created.body)}`);
+  }
+  const user = await loginAs(account.email, account.password);
+  return { ...account, id: user.id };
 }
 
 async function ensureToken() {

--- a/scripts/qa-lab/memory-experiment.mjs
+++ b/scripts/qa-lab/memory-experiment.mjs
@@ -88,8 +88,17 @@ for (const row of rows) {
 }
 console.log(`\n${rows.filter((r) => r.pass).length}/${rows.length} passed`);
 
+// Forgetting a memory is confirmation-gated (`FORGET_CONFIRMATION_REQUIRED`),
+// and this cleanup used to omit the flag and ignore the result. The 400 was
+// silent, so every run left its standing INSTRUCTION behind — and the NEXT run
+// then had two conflicting "always end your reply with …" memories live at
+// once, obeyed the older one, and reported a product failure that was really
+// its own litter. A cleanup whose failure is invisible is not a cleanup.
 if (memoryId !== null) {
-  await api('DELETE', `/memories/${memoryId}`);
+  const forgotten = await api('DELETE', `/memories/${memoryId}?confirm=FORGET`);
+  if (!forgotten.ok) {
+    console.log(`WARNING: could not forget ${memoryId} (${String(forgotten.status)}) — next run may see it`);
+  }
   await sleep(200);
 }
 writeJson(`${OUT}/summary.json`, { runId: RUN_ID, threadId: thread.id, memoryId, rows, answer });

--- a/scripts/qa-lab/stress-context.mjs
+++ b/scripts/qa-lab/stress-context.mjs
@@ -1,0 +1,326 @@
+// Long-thread stress: does the whole conversation still reach the model when a
+// thread runs to hundreds of messages?
+//
+// The earlier suites prove the CONTRACT at ordinary lengths (20-60 messages).
+// This one runs threads far past the point where the token budget must start
+// evicting, because that is where a context system either degrades honestly or
+// lies. Two different things are measured, and conflating them is how the
+// original defect survived so long:
+//
+//   DELIVERY  — did the composer hand the model every message it had budget
+//               for, and evict ONLY for budget? This is the product's promise
+//               and it must hold at every length.
+//   RECALL    — did the model then use what it was given? This is the model's
+//               job, and a weak model failing it is not a context bug.
+//
+// So every probe records the manifest alongside the answer. A recall failure on
+// a turn where the fact was demonstrably IN the prompt is reported as a model
+// result, never as a context regression.
+//
+// Memories are user-scoped and inject into every thread, so a shared account's
+// leftovers can compete with the facts a scenario plants. `--isolated` mints a
+// fresh account to rule that out; see the note above `createIsolatedUser` below
+// for why this particular harness does not need it, and what it costs.
+import {
+  login, createIsolatedUser, loadAllowedModels, createThread, sendMessage, awaitAssistant,
+  getReceipt, appendJsonl, writeJson, pool, assertFree,
+} from './client.mjs';
+
+const args = process.argv.slice(2).reduce((acc, cur, i, arr) => {
+  if (cur.startsWith('--')) acc[cur.slice(2)] = arr[i + 1] ?? 'true';
+  return acc;
+}, {});
+
+/** Threads to run in parallel families. */
+const THREADS = Number(args.threads ?? 12);
+/** User turns per thread. Each turn produces a user + an assistant message. */
+const TURNS = Number(args.turns ?? 120);
+/** Simultaneous in-flight generations across the whole run. */
+const WORKERS = Number(args.workers ?? 4);
+
+const RUN_ID = `STRESS-${Date.now().toString(36)}`;
+const OUT = `./results/${RUN_ID}`;
+
+const log = (msg) => {
+  const t = new Date().toISOString().slice(11, 19);
+  console.log(`[${t}] ${msg}`);
+};
+
+// Filler is deliberately boring and self-contained: it must add LENGTH without
+// adding facts that could be confused with the planted ones.
+const FILLER = [
+  'In one short sentence, what is a bloom filter?',
+  'In one short sentence, what is a write-ahead log?',
+  'In one short sentence, what is consistent hashing?',
+  'In one short sentence, what is a merkle tree?',
+  'In one short sentence, what is backpressure?',
+  'In one short sentence, what is a vector clock?',
+  'In one short sentence, what is quorum consensus?',
+  'In one short sentence, what is copy-on-write?',
+];
+
+// `--verbose` swaps in filler that asks for real prose.
+//
+// One-sentence answers are cheap, and a 432-message thread of them came to
+// 12,780 tokens against a 24,515 budget — so the eviction path never ran and
+// "0 delivery violations" only ever proved the easy case. Long answers push a
+// thread past its own window, which is where the composer has to start
+// choosing and where its choices are worth checking.
+const VERBOSE_FILLER = [
+  'Explain bloom filters in about 200 words, including false-positive behaviour.',
+  'Explain write-ahead logging in about 200 words, including crash recovery.',
+  'Explain consistent hashing in about 200 words, including virtual nodes.',
+  'Explain merkle trees in about 200 words, including anti-entropy repair.',
+  'Explain backpressure in about 200 words, including bounded queues.',
+  'Explain vector clocks in about 200 words, including concurrent updates.',
+  'Explain quorum consensus in about 200 words, including R + W > N.',
+  'Explain copy-on-write in about 200 words, including snapshot isolation.',
+];
+
+/**
+ * An upstream provider refusing on ITS OWN account limits, returned as a normal
+ * assistant message. Matched on the shape every such notice shares rather than
+ * on one vendor's wording, so a second provider's phrasing is still caught.
+ */
+const PROVIDER_LIMIT_PATTERN = /usage limit|rate limit|quota exceeded|upgrade for higher|insufficient (credit|balance)/i;
+
+const VERBOSE = args.verbose === 'true';
+const fillerAt = (turn) =>
+  VERBOSE ? VERBOSE_FILLER[turn % VERBOSE_FILLER.length] : FILLER[turn % FILLER.length];
+
+/**
+ * A thread of `TURNS` user turns that plants a uniquely-named fact every tenth
+ * turn and re-asks for earlier ones at ever-growing distance.
+ *
+ * Facts carry a per-thread nonce. Without one, a probe can be satisfied by
+ * another thread's value (or by a previous run's), which reads as a pass and
+ * hides a real failure.
+ */
+function buildPlan(nonce) {
+  const plan = [];
+  const facts = [];
+  for (let turn = 0; turn < TURNS; turn += 1) {
+    if (turn % 10 === 0) {
+      const index = facts.length + 1;
+      const value = `${nonce}-${String(index).padStart(2, '0')}`;
+      facts.push({ index, value, plantedAtTurn: turn });
+      plan.push({
+        kind: 'plant',
+        factIndex: index,
+        content: `Record this: parameter ${String(index)} is ${value}. Acknowledge in one short sentence.`,
+      });
+      continue;
+    }
+    // Probe on turns ending in 5. ALTERNATE between the very first fact and a
+    // recent one.
+    //
+    // The obvious design — cycle through the fact list — is what this used to
+    // do, and it quietly never tests anything: in a 432-message thread it
+    // asked at a maximum distance of 31 messages, because the cycle keeps
+    // landing on a recent fact. A distance test whose distance is bounded by
+    // its own indexing measures nothing about distance. Always re-asking
+    // fact #1 is what makes the probe distance grow with the thread.
+    if (turn % 5 === 0 && facts.length > 0) {
+      const askOldest = (turn / 5) % 2 === 1;
+      const target = askOldest ? facts[0] : facts[facts.length - 1];
+      plan.push({
+        kind: 'probe',
+        factIndex: target.index,
+        expect: target.value,
+        plantedAtTurn: target.plantedAtTurn,
+        content: `What is the value of parameter ${String(target.index)}? Reply with the value only, nothing else.`,
+      });
+      continue;
+    }
+    plan.push({ kind: 'filler', content: fillerAt(turn) });
+  }
+  return plan;
+}
+
+// `--isolated` mints a brand-new account, which is the right call whenever a
+// scenario plants a fact under a GENERIC name ("the project codename") that a
+// leftover memory could also claim. It costs quota headroom though: a fresh
+// account lands on the Free plan and its daily token quota is exhausted inside
+// ~15 turns of a long thread, so a run of this size cannot finish there.
+//
+// This harness does not need it. Every planted value carries a per-thread nonce
+// (`P<slot><time>-07`), so no stored memory can answer "what is the value of
+// parameter 7?" — a collision would require a memory naming that exact string.
+// Isolation stays available for scenarios that are not collision-proof.
+const isolated = args.isolated === 'true';
+const account = isolated ? await createIsolatedUser('stress') : await login();
+const models = await loadAllowedModels();
+const preferred = ['gpt-oss:20b', 'kimi-k3', 'glm-5.2', 'deepseek-v4-pro', 'gemma4:31b', 'minimax-m3'];
+const chosen = preferred.map((k) => models.find((m) => m.modelKey === k)).filter(Boolean);
+const roster = chosen.length > 0 ? chosen : models.slice(0, 6);
+for (const m of roster) assertFree(m.provider);
+
+log(`run ${RUN_ID}`);
+log(`account ${account.email ?? account.id} ${isolated ? '(fresh, zero memories)' : '(lab account; facts are nonce-scoped)'} · ${String(roster.length)} models`);
+log(`${String(THREADS)} threads x ${String(TURNS)} turns = ${String(THREADS * TURNS * 2)} messages, ${String(WORKERS)} workers`);
+log(`models: ${roster.map((m) => m.modelKey).join(', ')}\n`);
+
+const started = Date.now();
+let sent = 0;
+let failed = 0;
+let quotaExhausted = false;
+let providerLimited = false;
+
+async function runThread(slot) {
+  const model = roster[slot % roster.length];
+  const nonce = `P${slot.toString(36).toUpperCase()}${Date.now().toString(36).slice(-4).toUpperCase()}`;
+  const plan = buildPlan(nonce);
+  const label = `stress-${String(slot).padStart(2, '0')}-${model.modelKey}`;
+
+  const thread = await createThread({
+    title: `QA-LAB-${RUN_ID}-${label}`,
+    provider: model.provider,
+    model: model.modelKey,
+  });
+
+  let count = 0;
+  let probes = 0;
+  let recalled = 0;
+  let deliveryViolations = 0;
+  let unmeasured = 0;
+
+  for (const [turnIndex, step] of plan.entries()) {
+    const res = await sendMessage(thread.id, step.content, model.provider, model.modelKey);
+    if (!res.ok) {
+      failed += 1;
+      appendJsonl(`${OUT}/errors.jsonl`, { runId: RUN_ID, label, turnIndex, status: res.status, body: res.body });
+      // A quota rejection is not a flaky turn — every remaining thread will hit
+      // it too, and the run would otherwise finish "successfully" on a tenth of
+      // the messages it claims to have tested. Say so and stop.
+      if (res.status === 429) {
+        quotaExhausted = true;
+        log(`QUOTA EXHAUSTED at ${label} turn ${String(turnIndex)} — aborting run`);
+      }
+      break;
+    }
+    if (quotaExhausted || providerLimited) break;
+    sent += 1;
+    const reply = await awaitAssistant(thread.id, count, { timeoutMs: 300_000 });
+    if (!reply.ok) {
+      failed += 1;
+      appendJsonl(`${OUT}/errors.jsonl`, { runId: RUN_ID, label, turnIndex, reason: reply.reason });
+      break;
+    }
+    count = reply.total;
+
+    // The provider behind a PAYG-exempt connector has its own account limits,
+    // and when it hits one it answers 200 OK with a sentence of apology as the
+    // assistant message. Nothing upstream of here can tell that from a real
+    // reply: the turn succeeds, the message is stored, and a recall probe
+    // simply scores 0 because the marker is not in the refusal text.
+    //
+    // Measured: a run scored 34% recall and looked like context collapse past
+    // ~200 messages. 84 of its 127 probes were this string. Recall on the 43
+    // real answers was 43/43. A harness that cannot tell "the model answered
+    // wrongly" from "no model ran" reports the provider's billing state as a
+    // product defect.
+    if (PROVIDER_LIMIT_PATTERN.test(String(reply.message?.content ?? ''))) {
+      providerLimited = true;
+      log(`PROVIDER LIMIT hit at ${label} turn ${String(turnIndex)} — aborting run, results are not comparable`);
+      appendJsonl(`${OUT}/errors.jsonl`, {
+        runId: RUN_ID, label, turnIndex, reason: 'PROVIDER_USAGE_LIMIT',
+        answer: String(reply.message?.content ?? '').slice(0, 200),
+      });
+      break;
+    }
+
+    if (turnIndex > 0 && turnIndex % 25 === 0) {
+      log(`  ${label}: turn ${String(turnIndex)}/${String(plan.length)} · ${String(count)} msgs · recall ${String(recalled)}/${String(probes)}`);
+    }
+
+    if (step.kind !== 'probe') continue;
+
+    probes += 1;
+    const answer = String(reply.message?.content ?? '');
+    const hit = answer.toUpperCase().includes(step.expect.toUpperCase());
+    if (hit) recalled += 1;
+
+    const receipt = await getReceipt(reply.message.id);
+    const conv = receipt?.conversation ?? null;
+    const included = conv?.includedMessageIds?.length ?? null;
+    const total = conv?.totalThreadMessages ?? null;
+    const whole = included !== null && total !== null && included >= total;
+
+    // DELIVERY is the product's promise, and this is the assertion that would
+    // have caught the original defect: messages may be missing ONLY because the
+    // budget was genuinely consumed. A thread trimmed while 20%+ of the input
+    // budget is still unspent means something is dropping messages on a rule
+    // again — which is exactly how the old lexical-overlap filter behaved, and
+    // it left plenty of room unused while doing it.
+    const budget = conv?.availableInputTokens ?? null;
+    const used = conv?.estimatedInputTokens ?? null;
+    const roomLeft = budget !== null && used !== null && used < budget * 0.8;
+    // A probe with NO manifest proves nothing, and must never be scored as a
+    // pass. The first version of this check treated every null as "no
+    // violation", so a run where 84 of 127 probes produced no receipt at all
+    // still reported "DELIVERY violations 0" — the exact silent-pass shape this
+    // harness exists to catch, reproduced inside the harness.
+    const measured = conv !== null && total !== null;
+    const deliveryOk = measured && (whole || !roomLeft);
+    if (!measured) unmeasured += 1;
+    else if (!deliveryOk) deliveryViolations += 1;
+
+    const reasons = {};
+    for (const reason of Object.values(conv?.omissionReasons ?? {})) {
+      reasons[reason] = (reasons[reason] ?? 0) + 1;
+    }
+
+    appendJsonl(`${OUT}/probes.jsonl`, {
+      runId: RUN_ID, label, model: model.modelKey, turnIndex,
+      factIndex: step.factIndex, expect: step.expect,
+      distanceMessages: count - (step.plantedAtTurn * 2 + 1),
+      threadMessages: count,
+      recalled: hit,
+      includedMessages: included,
+      totalThreadMessages: total,
+      wholeThreadSent: whole,
+      estimatedInputTokens: used,
+      availableInputTokens: budget,
+      omittedMessages: conv?.omittedMessageIds?.length ?? null,
+      omissionReasons: reasons,
+      contextWindowSource: conv?.contextWindowSource ?? null,
+      retrievalMs: conv?.retrievalMs ?? null,
+      selectionMs: conv?.selectionMs ?? null,
+      deliveryOk,
+      answer: answer.replace(/\s+/g, ' ').slice(0, 120),
+    });
+  }
+
+  log(
+    `done ${label}: ${String(count)} msgs · recall ${String(recalled)}/${String(probes)} · ` +
+      `delivery violations ${String(deliveryViolations)} · unmeasured ${String(unmeasured)}`,
+  );
+  return { label, model: model.modelKey, messages: count, probes, recalled, deliveryViolations, unmeasured };
+}
+
+const threads = await pool(Array.from({ length: THREADS }, (_, i) => i), WORKERS, (slot) => runThread(slot));
+const ok = threads.filter((t) => t && t.messages !== undefined);
+
+const totalMessages = ok.reduce((a, t) => a + t.messages, 0);
+const totalProbes = ok.reduce((a, t) => a + t.probes, 0);
+const totalRecalled = ok.reduce((a, t) => a + t.recalled, 0);
+const totalViolations = ok.reduce((a, t) => a + t.deliveryViolations, 0);
+const totalUnmeasured = ok.reduce((a, t) => a + t.unmeasured, 0);
+
+console.log('\n=== STRESS: LONG THREADS ===');
+console.log(`  threads            ${String(ok.length)}/${String(THREADS)}`);
+console.log(`  messages in threads${String(totalMessages).padStart(8)}`);
+console.log(`  turns sent         ${String(sent).padStart(8)}  failed ${String(failed)}`);
+console.log(`  recall             ${String(totalRecalled)}/${String(totalProbes)}`);
+console.log(`  DELIVERY violations${String(totalViolations).padStart(8)}   <- must be 0`);
+console.log(`  unmeasured probes  ${String(totalUnmeasured).padStart(8)}   <- no manifest; proves nothing`);
+console.log(`  wall clock         ${String(Math.round((Date.now() - started) / 1000))}s`);
+
+writeJson(`${OUT}/summary.json`, {
+  runId: RUN_ID, threads: THREADS, turns: TURNS, workers: WORKERS,
+  models: roster.map((m) => m.modelKey),
+  totalMessages, totalProbes, totalRecalled, totalViolations, totalUnmeasured, sent, failed,
+  wallClockSec: Math.round((Date.now() - started) / 1000),
+  perThread: ok,
+});
+console.log(`\nresults in ${OUT}`);


### PR DESCRIPTION
Three changes, found by building a long-thread context stress test and running it against `claw.local`. Two are production bugs; the third is the harness that found them.

## 1. routing-service crashes under sustained load

`commitCalibrationBatch` replaces the live router profile tables with `deleteMany()` + `createMany()`. Under READ COMMITTED that pair races itself: if the second transaction's DELETE takes its snapshot before the first COMMITs, it removes only the rows it can see, never observes the rows the first is inserting, and its own INSERT violates `router_model_profiles_provider_model_task_family_topic_key_key`.

**Severity is the part that matters.** `rebuildCalibrationSnapshot()` runs on *every routing outcome* — after every single generation. So every pair of concurrent messages is an opportunity, and the P2002 is an unhandled rejection that kills the process. routing-service down means `/routing/models` 502s and **no message can be routed at all**.

Reproduced twice during the stress run: every in-flight thread timed out at the same instant because the routing tier had died.

**It degrades with age, which is why nobody caught it.** `findEducationWindow` returns a growing window of decisions, so the transaction lengthens the more the system is used. 24 concurrent generations on a young database were clean. It crashed reliably after ~1,400. A load test on a fresh install passes.

Fix: a transaction-scoped advisory lock as the first statement of both replace paths (`restoreCalibrationSnapshot` too — a rollback replaces the same tables the same way). Released on COMMIT or ROLLBACK, so a crashed transaction cannot strand it.

The `::text` cast is load-bearing and matches the three existing seed repositories in this service: `pg_advisory_xact_lock` returns `void`, which the Prisma pg adapter cannot decode. My first attempt omitted it and crashed the service *faster* than the bug it was fixing. Verified at runtime rather than only in tests — lock `740040004` was observed held in `pg_locks` during live load.

**Not addressed here:** rebuilding the entire calibration window once per message is O(accumulated decisions) per generation. The lock makes that correct, not cheap. Worth a separate decision.

## 2. Marketing pages fail colour contrast — in both themes

`.editorial-comparison__cta` is an inverted panel (`background: var(--editorial-ink)`). The inversion itself is theme-safe, because ink and paper swap together. But two children re-set `color` from tokens tuned for the *paper* ground:

| element | token | light | dark |
|---|---|---|---|
| `__verdict-label` | `--editorial-signal` | 3.41:1 | **2.26:1** |
| `__body` | `--editorial-graphite` | 2.98:1 | **1.76:1** |

All four are under 4.5:1, so this was broken in **both** themes — dark just fails loudly enough for axe to report it.

Scope explains itself: compare pages put bare text in the panel and inherit its colour, so they were never affected. Only learn and integration *topic* pages nest these two inside it — exactly the 32 URLs Lighthouse failed, and no others. The hub pages passed.

Verified with real Lighthouse against rendered pages: `color-contrast` = 1 and `categories.accessibility` = 1.0 on a learn topic page, an integrations topic page, and a compare page.

This gate is currently **red on main** (it began failing when the SEO cluster landed; main's own run fails identically). This PR should turn it green.

## 3. The stress harness

`scripts/qa-lab/stress-context.mjs`. Threads run to hundreds of messages, past the point where the token budget must start evicting — that is where a context system either degrades honestly or lies.

It measures two things and refuses to conflate them, because conflating them is how the original context defect survived so long:

- **DELIVERY** — did the composer hand the model every message it had budget for, and omit *only* for budget? The product's promise.
- **RECALL** — did the model then use what it was given? The model's job. A weak model failing here is not a context bug.

**Results on `claw.local`, free models only** (the harness refuses metered providers in code):

- 4,400 messages over 2,200 turns, 6 models, **0 failed**, recall **220/220**, delivery violations **0**, threads reaching 432 messages
- assembly cost flat with length: selection **1 ms** p50 (6 ms max at 432 messages), retrieval **8 ms** p50
- a verbose second run filled the budget to **24,510 / 24,515 tokens** and evicted for real — recall stayed **43/43** at up to **211 messages back**

### Three flaws in the harness itself

Each turned a red result green — the same silent-degradation shape the harness exists to catch. Recording them because the numbers above are only trustworthy *because* these were found:

1. The delivery check counted a **missing** manifest as "no violation". A run where 84 of 127 probes produced no receipt still printed `DELIVERY violations 0`. Unmeasured probes are now counted separately and prove nothing.
2. A probe scored 0 when the upstream provider answered 200 OK with its own usage-limit notice as the assistant message. That read as context collapse past ~200 messages; it was the provider's billing state. Now detected, and it aborts the run, because results afterwards are not comparable.
3. The probe selector cycled through planted facts, which keeps landing on recent ones — a 432-message thread was probed at a maximum distance of **31**. A distance test bounded by its own indexing measures nothing. It now always re-asks the first fact, so distance grows with the thread.

### Lab hygiene, same family of bug

- `client.mjs` gains `loginAs` / `createIsolatedUser`. Memories are **user-scoped** and inject into every thread, so a shared lab account accumulates fixtures that compete with planted facts — a stored `The internal project codename is ORCHID-2728` made three recall probes fail at distances 4, 24 and 56 at *identical* rates, which is the signature of a constant competing fact, not of context loss. Isolation is opt-in because a fresh account lands on the Free plan and exhausts its daily quota in ~15 turns.
- `memory-experiment.mjs`: forgetting is confirmation-gated, and the cleanup omitted `?confirm=FORGET` **and ignored the 400**. Every run left its standing INSTRUCTION behind, so the next run had two conflicting "always end your reply with …" memories live and obeyed the older one — reporting its own litter as a product failure.

## Testing

- routing-service: typecheck clean, `routing-education.repository.spec.ts` 8/8 (new test asserts the lock is the **first** operation — one taken after the DELETE would block nothing)
- frontend: typecheck clean; Lighthouse verified on three page types
- all commits gated through the real pre-commit and pre-push hooks

## Not in this PR

- the O(n)-per-message calibration rebuild
- restoring the fix to the local Docker stack (it bind-mounts the main worktree, so routing-service runs unpatched until this merges)
- the pre-existing `package-lock.json` version drift (`1.36.2` vs `1.59.0`), deliberately left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)