### PR TITLE
fix(chat-service): remove dead runtime path-alias registration crashing prod boot

### DIFF
--- a/apps/claw-chat-service/package.json
+++ b/apps/claw-chat-service/package.json
@@ -47,7 +47,6 @@
     "pino-pretty": "^13.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "tsconfig-paths": "^4.2.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/apps/claw-chat-service/src/main.ts
+++ b/apps/claw-chat-service/src/main.ts
@@ -1,7 +1,3 @@
-// Register path aliases at runtime (replaces the build-time path rewrite step).
-// Must run before any other @app/* @common/* @infrastructure/* @modules/* import.
-import { register as registerTsConfigPaths } from 'tsconfig-paths';
-
 import { NestFactory } from '@nestjs/core';
 import type { NestExpressApplication } from '@nestjs/platform-express';
 import * as fs from 'node:fs';
@@ -11,16 +7,6 @@ import { RabbitMQLoggerService, RabbitMQService } from '@claw/shared-rabbitmq';
 import { AppModule } from './app/app.module';
 import { AppConfig } from './app/config/app.config';
 import { configureChatBodyParser } from './app/utilities/chat-body-parser.utility';
-
-registerTsConfigPaths({
-  baseUrl: __dirname,
-  paths: {
-    '@app/*': ['app/*'],
-    '@common/*': ['common/*'],
-    '@infrastructure/*': ['infrastructure/*'],
-    '@modules/*': ['modules/*'],
-  },
-});
 
 // --- Inline HTTPS bootstrap (no-rebuild path; see scripts/_patch-main-ts-inline.cjs) ---
 function resolveHttpsOptions(): { cert: Buffer; key: Buffer } | undefined {


### PR DESCRIPTION
## Summary
- `dist/main.js` crashed on every single boot with `ReferenceError: __dirname is not defined in ES module scope` — chat-service's `package.json` has `"type": "module"`, and `__dirname` does not exist in ES modules.
- Root cause: `registerTsConfigPaths({ baseUrl: __dirname, ... })` in `main.ts` was added when this service briefly built with `tsgo` alone (commit `4e3ce3abc`) and needed runtime path-alias resolution. Once `tsc-alias` was added back to chat-service's build script (matching every other service), it started rewriting `@app/*`/`@common/*`/etc. to real relative `./app/*.js` imports at build time — making the runtime registration fully redundant. It was never removed, so it kept unconditionally referencing `__dirname` on every boot.
- Fix: deleted the dead `registerTsConfigPaths` block and its `tsconfig-paths` import/dependency. No other service has this pattern (confirmed by repo-wide grep) and no other file in chat-service depends on it.

## Release notes
chat-service is broken in production right now — every container crashes immediately on boot. This restores it to booting correctly.

## Remaining work
None. This is a minimal, targeted fix — two files changed, nothing else touched.

## Test plan
- [x] `npx tsgo --noEmit` — clean
- [x] `npm run lint` — 0 errors (71 pre-existing warnings, unrelated to this change)
- [x] `npm run test` — 1616/1616 tests passing (2 suites hit a pre-existing Windows/Jest path-resolution flake unrelated to this change — verified the flaky files pass 26/26 in isolation)
- [x] `npm run build` — confirmed `dist/main.js` contains **zero** `__dirname` references and **zero** bare `@app/`/`@common/`/`@infrastructure/`/`@modules/` specifiers (`tsc-alias` already resolves all of them to relative `.js` imports)
- [x] Booted `dist/main.js` directly: it now proceeds through NestJS module resolution and DI all the way to `AppConfig.validate()`, failing only on missing env vars in this isolated worktree (expected — no `.env` here). Previously it crashed before a single import even resolved.