### PR TITLE
fix(frontend): use navigation for VS Code loopback auth callback

### DIFF
--- a/apps/claw-frontend/src/repositories/auth/__tests__/vscode-authorization.repository.test.ts
+++ b/apps/claw-frontend/src/repositories/auth/__tests__/vscode-authorization.repository.test.ts
@@ -47,16 +47,29 @@ describe('VS Code authorization repository', () => {
     });
   });
 
-  it('delivers loopback authorization without navigating away from ClawAI', async () => {
-    const fetcher = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+  it('delivers loopback authorization with a top-level browser navigation', () => {
+    const navigate = vi.fn();
     const callback = 'http://127.0.0.1:64215/auth/callback?code=one-time-code&state=verified-state';
 
-    await deliverVscodeAuthorization(callback, fetcher);
+    deliverVscodeAuthorization(callback, navigate);
 
-    expect(fetcher).toHaveBeenCalledWith(callback, {
-      cache: 'no-store',
-      credentials: 'omit',
-      mode: 'no-cors',
-    });
+    expect(navigate).toHaveBeenCalledOnce();
+    expect(navigate).toHaveBeenCalledWith(callback);
+  });
+
+  it.each([
+    'https://127.0.0.1:64215/auth/callback?code=code&state=state',
+    'http://127.0.0.1/auth/callback?code=code&state=state',
+    'http://localhost:64215/auth/callback?code=code&state=state',
+    'http://example.com:64215/auth/callback?code=code&state=state',
+    'http://user:password@127.0.0.1:64215/auth/callback?code=code&state=state',
+    'http://127.0.0.1:64215/not-auth/callback?code=code&state=state',
+  ])('rejects an unsafe loopback authorization callback: %s', (callback) => {
+    const navigate = vi.fn();
+
+    expect(() => deliverVscodeAuthorization(callback, navigate)).toThrow(
+      'Invalid VS Code authorization callback.',
+    );
+    expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/apps/claw-frontend/src/repositories/auth/vscode-authorization.repository.ts
+++ b/apps/claw-frontend/src/repositories/auth/vscode-authorization.repository.ts
@@ -6,6 +6,12 @@ import type {
 
 const BASE = '/auth/vscode/authorize';
 
+type VscodeAuthorizationNavigator = (callbackUrl: string) => void;
+
+function navigateToCallback(callbackUrl: string): void {
+  window.location.assign(callbackUrl);
+}
+
 export async function getVscodeAuthorizationDetails(
   requestId: string,
 ): Promise<VscodeAuthorizationDetails> {
@@ -24,18 +30,27 @@ export async function approveVscodeAuthorization(
   return response.data;
 }
 
-export async function deliverVscodeAuthorization(
+export function deliverVscodeAuthorization(
   redirectUri: string,
-  fetcher: typeof fetch = globalThis.fetch,
-): Promise<void> {
+  navigate: VscodeAuthorizationNavigator = navigateToCallback,
+): void {
   const callback = new URL(redirectUri);
   const isLoopback = callback.hostname === '127.0.0.1' || callback.hostname === '[::1]';
-  if (callback.protocol !== 'http:' || !isLoopback || callback.pathname !== '/auth/callback') {
+  const hasExplicitPort = callback.port.length > 0;
+  const hasCredentials = callback.username.length > 0 || callback.password.length > 0;
+
+  if (
+    callback.protocol !== 'http:' ||
+    !isLoopback ||
+    !hasExplicitPort ||
+    hasCredentials ||
+    callback.pathname !== '/auth/callback'
+  ) {
     throw new Error('Invalid VS Code authorization callback.');
   }
-  await fetcher(callback.href, {
-    cache: 'no-store',
-    credentials: 'omit',
-    mode: 'no-cors',
-  });
+
+  // A browser fetch from the HTTPS ClawAI app to a loopback HTTP server can be
+  // blocked before CORS is evaluated. Native OAuth loopback callbacks are a
+  // browser navigation handoff, so keep the callback constrained and navigate.
+  navigate(callback.href);
 }


### PR DESCRIPTION
## Summary
- replace the production browser `fetch()` to the Coding Agent loopback callback with a validated top-level navigation
- keep the callback restricted to HTTP loopback, an explicit port, the expected `/auth/callback` path, and URLs without credentials
- update repository regression coverage to assert navigation and reject unsafe callback URLs

## Why
The production authorization page is served over HTTPS, while the Coding Agent listens on an ephemeral `http://127.0.0.1:<port>` callback. Browser local-network security can block that cross-origin fetch before ordinary CORS handling, producing `Failed to fetch` / `(blocked:other)`. A native OAuth loopback callback is a browser navigation handoff, not a browser API fetch.

## Companion repository audit
`ClawAI-Coding-Agent` already exposes the loopback GET listener, validates the callback state, completes token exchange, and returns a terminal success/failure HTML page. No companion change is required.